### PR TITLE
Allow one to sync non-bare local git repository

### DIFF
--- a/lib/modulesync/git.rb
+++ b/lib/modulesync/git.rb
@@ -38,7 +38,7 @@ module ModuleSync
       # Repo needs to be cloned in the cwd
       if ! Dir.exists?("#{PROJ_ROOT}/#{name}") || ! Dir.exists?("#{PROJ_ROOT}/#{name}/.git")
         puts "Cloning repository fresh"
-        remote = opts[:remote] || "#{git_base}/#{name}.git"
+        remote = opts[:remote] || git_base.start_with?('file://') ? "#{git_base}/#{name}" : "#{git_base}/#{name}.git"
         local = "#{PROJ_ROOT}/#{name}"
         puts "Cloning from #{remote}"
         repo = ::Git.clone(remote, local)


### PR DESCRIPTION
One can currently manage bare local git repositories with modulesync but
cannot manage non-bare git repositories. This commit aims to add this
feature.

If I was to have several local directories (from git clone), I can't keep
them in sync with modulesync as git clone would complain about :

fatal: '/tmp/puppet/openstack/puppet-nova.git' does not
appear to be a git repository
fatal: Could not read from remote repository.

Yet '/tmp/puppet/openstack/puppet-nova' is a valid path with a .git
directory in it.

This is due to the '.git' appended at the end when protocol is file.