### PR TITLE
Create --offline flag to disable git functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,17 @@ overwrites local changes.
 msync update --noop
 ```
 
+#### Offline support
+The --offline flag was added to allow a user to disable git support within
+msync. One reason for this is because the user wants to control git commands
+external to msync.  Note, when using this command, msync assumes you have
+create the folder structure and git repositories correctly. If not, msync will
+fail to update correctly.
+
+```
+msync update --offline
+```
+
 #### Damage mode
 
 Make changes for real and push them back to master. This operates on the

--- a/features/update.feature
+++ b/features/update.feature
@@ -103,6 +103,18 @@ Feature: update
       """
       require 'puppetlabs_spec_helper/module_helper'
       """
+    When I run `msync update --offline --noop`
+    Then the exit status should be 0
+    And the output should match:
+      """
+      Files added:\s+
+      spec/spec_helper.rb
+      """
+    When I run `msync update --offline`
+    Then the exit status should be 0
+    And the output should match:
+      """
+      """
 
   Scenario: Updating a module with a .sync.yml file
     Given a file named "managed_modules.yml" with:

--- a/lib/modulesync.rb
+++ b/lib/modulesync.rb
@@ -56,8 +56,10 @@ module ModuleSync
       # managed_modules is either an array or a hash
       managed_modules.each do |puppet_module, opts|
         puts "Syncing #{puppet_module}"
-        git_base = "#{options[:git_base]}#{options[:namespace]}"
-        Git.pull(git_base, puppet_module, options[:branch], opts || {})
+        unless options[:offline]
+          git_base = "#{options[:git_base]}#{options[:namespace]}"
+          Git.pull(git_base, puppet_module, options[:branch], opts || {})
+        end
         module_configs = Util.parse_config("#{PROJ_ROOT}/#{puppet_module}/#{MODULE_CONF_FILE}")
         global_defaults = defaults[GLOBAL_DEFAULTS_KEY] || {}
         module_defaults = module_configs[GLOBAL_DEFAULTS_KEY] || {}
@@ -80,7 +82,7 @@ module ModuleSync
         files_to_manage -= files_to_delete
         if options[:noop]
           Git.update_noop(puppet_module, options)
-        else
+        elsif not options[:offline]
           Git.update(puppet_module, files_to_manage, options)
         end
       end

--- a/lib/modulesync/cli.rb
+++ b/lib/modulesync/cli.rb
@@ -35,7 +35,7 @@ module ModuleSync
       @options.merge!(Hash.transform_keys_to_symbols(Util.parse_config(MODULESYNC_CONF_FILE)))
       @options[:command] = args[0] if commands_available.include?(args[0])
       opt_parser = OptionParser.new do |opts|
-        opts.banner = "Usage: msync update [-m <commit message>] [-c <directory> ] [--noop] [--bump] [--changelog] [--tag] [--tag-pattern <tag_pattern>] [-n <namespace>] [-b <branch>] [-r <branch>] [-f <filter>] | hook activate|deactivate [-c <directory> ] [-n <namespace>] [-b <branch>]"
+        opts.banner = "Usage: msync update [-m <commit message>] [-c <directory> ] [--offline] [--noop] [--bump] [--changelog] [--tag] [--tag-pattern <tag_pattern>] [-n <namespace>] [-b <branch>] [-r <branch>] [-f <filter>] | hook activate|deactivate [-c <directory> ] [-n <namespace>] [-b <branch>]"
         opts.on('-m', '--message <msg>',
                 'Commit message to apply to updated modules') do |msg|
           @options[:message] = msg
@@ -72,6 +72,10 @@ module ModuleSync
                 'No-op mode') do |msg|
           @options[:noop] = true
         end
+        opts.on('--offline',
+                'Do not run git command. Helpful if you have existing repositories locally.') do |msg|
+          @options[:offline] = true
+        end
         opts.on('--bump',
                 'Bump module version to the next minor') do |msg|
           @options[:bump] = true
@@ -92,8 +96,8 @@ module ModuleSync
       end.parse!
 
       @options.fetch(:message) do
-        if @options[:command] == 'update' && ! @options[:noop] && ! @options[:amend]
-          fail("A commit message is required unless using noop.")
+        if @options[:command] == 'update' && ! @options[:noop] && ! @options[:amend] && ! @options[:offline]
+          fail("A commit message is required unless using noop or offline.")
         end
       end
 


### PR DESCRIPTION
This allows existing cloned projects to be used for testing purposes.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>