### PR TITLE
Add --project-root flag

### DIFF
--- a/features/update.feature
+++ b/features/update.feature
@@ -30,6 +30,35 @@ Feature: update
     Given I run `cat modules/puppet-test/test`
     Then the output should contain "aruba"
 
+  Scenario: Adding a new file into foobar project-root
+    Given a file named "managed_modules.yml" with:
+      """
+      ---
+        - puppet-test
+      """
+    And a file named "modulesync.yml" with:
+      """
+      ---
+        namespace: maestrodev
+        git_base: https://github.com/
+      """
+    And a file named "config_defaults.yml" with:
+      """
+      ---
+      test:
+        name: aruba
+      """
+    And a directory named "moduleroot"
+    And a file named "moduleroot/test" with:
+      """
+      <%= @configs['name'] %>
+      """
+    When I run `msync update --noop --project-root=foobar`
+    Then the exit status should be 0
+    And the output should match /Files added:\s+test/
+    Given I run `cat foobar/puppet-test/test`
+    Then the output should contain "aruba"
+
   Scenario: Modifying an existing file
     Given a file named "managed_modules.yml" with:
       """

--- a/lib/modulesync.rb
+++ b/lib/modulesync.rb
@@ -13,8 +13,8 @@ module ModuleSync
     "#{config_path}/#{MODULE_FILES_DIR}/#{file}"
   end
 
-  def self.module_file(puppet_module, file)
-    "#{PROJ_ROOT}/#{puppet_module}/#{file}"
+  def self.module_file(project_root, puppet_module, file)
+    "#{project_root}/#{puppet_module}/#{file}"
   end
 
   def self.local_files(path)
@@ -58,9 +58,9 @@ module ModuleSync
         puts "Syncing #{puppet_module}"
         unless options[:offline]
           git_base = "#{options[:git_base]}#{options[:namespace]}"
-          Git.pull(git_base, puppet_module, options[:branch], opts || {})
+          Git.pull(git_base, puppet_module, options[:branch], options[:project_root], opts || {})
         end
-        module_configs = Util.parse_config("#{PROJ_ROOT}/#{puppet_module}/#{MODULE_CONF_FILE}")
+        module_configs = Util.parse_config("#{options[:project_root]}/#{puppet_module}/#{MODULE_CONF_FILE}")
         global_defaults = defaults[GLOBAL_DEFAULTS_KEY] || {}
         module_defaults = module_configs[GLOBAL_DEFAULTS_KEY] || {}
         files_to_manage = (module_files | defaults.keys | module_configs.keys) - [GLOBAL_DEFAULTS_KEY]
@@ -72,11 +72,11 @@ module ModuleSync
             puts "Not managing #{file} in #{puppet_module}"
             files_to_delete << file
           elsif file_configs['delete']
-            Renderer.remove(module_file(puppet_module, file))
+            Renderer.remove(module_file(options['project_root'], puppet_module, file))
           else
             erb = Renderer.build(local_file(options[:configs], file))
             template = Renderer.render(erb, file_configs)
-            Renderer.sync(template, "#{PROJ_ROOT}/#{puppet_module}/#{file}")
+            Renderer.sync(template, "#{options[:project_root]}/#{puppet_module}/#{file}")
           end
         end
         files_to_manage -= files_to_delete

--- a/lib/modulesync/cli.rb
+++ b/lib/modulesync/cli.rb
@@ -14,6 +14,7 @@ module ModuleSync
         :managed_modules_conf => 'managed_modules.yml',
         :configs              => '.',
         :tag_pattern          => '%s',
+        :project_root         => './modules',
       }
     end
 
@@ -35,7 +36,7 @@ module ModuleSync
       @options.merge!(Hash.transform_keys_to_symbols(Util.parse_config(MODULESYNC_CONF_FILE)))
       @options[:command] = args[0] if commands_available.include?(args[0])
       opt_parser = OptionParser.new do |opts|
-        opts.banner = "Usage: msync update [-m <commit message>] [-c <directory> ] [--offline] [--noop] [--bump] [--changelog] [--tag] [--tag-pattern <tag_pattern>] [-n <namespace>] [-b <branch>] [-r <branch>] [-f <filter>] | hook activate|deactivate [-c <directory> ] [-n <namespace>] [-b <branch>]"
+        opts.banner = "Usage: msync update [-m <commit message>] [-c <directory> ] [--offline] [--noop] [--bump] [--changelog] [--tag] [--tag-pattern <tag_pattern>] [-p <project_root> [-n <namespace>] [-b <branch>] [-r <branch>] [-f <filter>] | hook activate|deactivate [-c <directory> ] [-n <namespace>] [-b <branch>]"
         opts.on('-m', '--message <msg>',
                 'Commit message to apply to updated modules') do |msg|
           @options[:message] = msg
@@ -51,6 +52,10 @@ module ModuleSync
         opts.on('-b', '--branch <branch>',
                 'Branch name to make the changes in. Defaults to "master"') do |branch|
           @options[:branch] = branch
+        end
+        opts.on('-p', '--project-root <path>',
+                'Path used by git to clone modules into. Defaults to "modules"') do |project_root|
+          @options[:project_root] = project_root
         end
         opts.on('-r', '--remote-branch <branch>',
                 'Remote branch name to push the changes to. Defaults to the branch name') do |branch|

--- a/lib/modulesync/constants.rb
+++ b/lib/modulesync/constants.rb
@@ -4,7 +4,6 @@ module ModuleSync
     CONF_FILE            = 'config_defaults.yml'
     MODULE_CONF_FILE     = '.sync.yml'
     MODULESYNC_CONF_FILE = 'modulesync.yml'
-    PROJ_ROOT            = './modules'
     HOOK_FILE            = '.git/hooks/pre-push'
     GLOBAL_DEFAULTS_KEY  = :global
   end

--- a/lib/modulesync/git.rb
+++ b/lib/modulesync/git.rb
@@ -30,24 +30,24 @@ module ModuleSync
       end
     end
 
-    def self.pull(git_base, name, branch, opts)
-      if ! Dir.exists?(PROJ_ROOT)
-        Dir.mkdir(PROJ_ROOT)
+    def self.pull(git_base, name, branch, project_root, opts)
+      if ! Dir.exists?(project_root)
+        Dir.mkdir(project_root)
       end
 
       # Repo needs to be cloned in the cwd
-      if ! Dir.exists?("#{PROJ_ROOT}/#{name}") || ! Dir.exists?("#{PROJ_ROOT}/#{name}/.git")
+      if ! Dir.exists?("#{opts[:project_root]}/#{name}") || ! Dir.exists?("#{opts[:project_root]}/#{name}/.git")
         puts "Cloning repository fresh"
         remote = opts[:remote] || (git_base.start_with?('file://') ? "#{git_base}/#{name}" : "#{git_base}/#{name}.git")
-        local = "#{PROJ_ROOT}/#{name}"
+        local = "#{project_root}/#{name}"
         puts "Cloning from #{remote}"
         repo = ::Git.clone(remote, local)
         switch_branch(repo, branch)
       # Repo already cloned, check out master and override local changes
       else
         # Some versions of git can't properly handle managing a repo from outside the repo directory
-        Dir.chdir("#{PROJ_ROOT}/#{name}") do
-          puts "Overriding any local changes to repositories in #{PROJ_ROOT}"
+        Dir.chdir("#{project_root}/#{name}") do
+          puts "Overriding any local changes to repositories in #{project_root}"
           repo = ::Git.open('.')
           repo.fetch
           repo.reset_hard
@@ -96,7 +96,7 @@ module ModuleSync
 
     # Git add/rm, git commit, git push
     def self.update(name, files, options)
-      module_root = "#{PROJ_ROOT}/#{name}"
+      module_root = "#{options[:project_root]}/#{name}"
       message = options[:message]
       if options[:remote_branch]
         branch = "#{options[:branch]}:#{options[:remote_branch]}"
@@ -159,7 +159,7 @@ module ModuleSync
     def self.update_noop(name, options)
       puts "Using no-op. Files in #{name} may be changed but will not be committed."
 
-      repo = ::Git.open("#{PROJ_ROOT}/#{name}")
+      repo = ::Git.open("#{options[:project_root]}/#{name}")
       repo.branch(options[:branch]).checkout
 
       puts "Files changed: "


### PR DESCRIPTION
This allows the user to now define the previously hardcoded './modules' folder.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>