### PR TITLE
Fix bug in git pull function

### DIFF
--- a/lib/modulesync/git.rb
+++ b/lib/modulesync/git.rb
@@ -36,7 +36,7 @@ module ModuleSync
       end
 
       # Repo needs to be cloned in the cwd
-      if ! Dir.exists?("#{opts[:project_root]}/#{name}") || ! Dir.exists?("#{opts[:project_root]}/#{name}/.git")
+      if ! Dir.exists?("#{project_root}/#{name}") || ! Dir.exists?("#{project_root}/#{name}/.git")
         puts "Cloning repository fresh"
         remote = opts[:remote] || (git_base.start_with?('file://') ? "#{git_base}/#{name}" : "#{git_base}/#{name}.git")
         local = "#{project_root}/#{name}"


### PR DESCRIPTION
The commit to add a --project-root flag mistakenly tried to use the
opts variable passed in, which is not actually the options hash of
command line arguments. The project_root variable is exposed in the
function, so use that instead.

Closes #55