### PR TITLE
Refactoring the Hook module into a class

### DIFF
--- a/features/hook.feature
+++ b/features/hook.feature
@@ -16,3 +16,13 @@ Feature: hook
     When I run `msync hook deactivate`
     Then the exit status should be 0
     Then the file ".git/hooks/pre-push" should not exist
+
+  Scenario: Activating a hook with arguments
+    Given a directory named ".git/hooks"
+    When I run `msync hook activate -a '--foo bar --baz quux' -b master`
+    Then the exit status should be 0
+    Given I run `cat .git/hooks/pre-push`
+    Then the output should match:
+      """
+      "\$message" -n puppetlabs -b master --foo bar --baz quux
+      """

--- a/lib/modulesync/cli.rb
+++ b/lib/modulesync/cli.rb
@@ -7,19 +7,20 @@ module ModuleSync
   class CLI
     class Hook < Thor
       class_option :project_root, :aliases => '-c', :desc => 'Path used by git to clone modules into. Defaults to "modules"', :default => 'modules'
+      class_option :hook_args, :aliases => '-a', :desc => 'Arguments to pass to msync in the git hook'
 
-      desc 'activate', 'Activate a git hook.'
+      desc 'activate', 'Activate the git hook.'
       def activate
         config = { :command => 'hook' }.merge(options)
         config[:hook] = 'activate'
-        ModuleSync.run(config)
+        ModuleSync.hook(config)
       end
 
-      desc 'deactivate', 'Deactivate a git hook.'
+      desc 'deactivate', 'Deactivate the git hook.'
       def deactivate
         config = { :command => 'hook' }.merge(options)
         config[:hook] = 'deactivate'
-        ModuleSync.run(config)
+        ModuleSync.hook(config)
       end
     end
 
@@ -27,14 +28,14 @@ module ModuleSync
       include Constants
 
       class_option :project_root, :aliases => '-c', :desc => 'Path used by git to clone modules into. Defaults to "modules"', :default => 'modules'
+      class_option :namespace, :aliases => '-n', :desc => 'Remote github namespace (user or organization) to clone from and push to. Defaults to puppetlabs', :default => 'puppetlabs'
+      class_option :filter, :aliases => '-f', :desc => 'A regular expression to filter repositories to update.'
+      class_option :branch, :aliases => '-b', :desc => 'Branch name to make the changes in. Defaults to master.', :default => 'master'
 
       desc 'update', 'Update the modules in managed_modules.yml'
       option :message, :aliases => '-m', :desc => 'Commit message to apply to updated modules. Required unless running in noop mode.'
-      option :namespace, :aliases => '-n', :desc => 'Remote github namespace (user or organization) to clone from and push to. Defaults to puppetlabs', :default => 'puppetlabs'
       option :configs, :aliases => '-c', :desc => 'The local directory or remote repository to define the list of managed modules, the file templates, and the default values for template variables.'
-      option :branch, :aliases => '-b', :desc => 'Branch name to make the changes in. Defaults to master.', :default => 'master'
       option :remote_branch, :aliases => '-r', :desc => 'Remote branch name to push the changes to. Defaults to the branch name.'
-      option :filter, :aliases => '-f', :desc => 'A regular expression to filter repositories to update.'
       option :amend, :type => :boolean, :desc => 'Amend previous commit', :default => false
       option :force, :type => :boolean, :desc => 'Force push amended commit', :default => false
       option :noop, :type => :boolean, :desc => 'No-op mode', :default => false
@@ -50,7 +51,7 @@ module ModuleSync
         config = Util.symbolize_keys(config)
         fail Thor::Error, 'No value provided for required option "--message"' unless config[:noop] || config[:message] || config[:offline]
         config[:git_opts] = { 'amend' => config[:amend], 'force' => config[:force] }
-        ModuleSync.run(config)
+        ModuleSync.update(config)
       end
 
       desc 'hook', 'Activate or deactivate a git hook.'

--- a/lib/modulesync/hook.rb
+++ b/lib/modulesync/hook.rb
@@ -1,36 +1,40 @@
-module ModuleSync
-  module Hook
-    include Constants
+require 'modulesync'
 
-    def self.activate(args)
-      repo = args[:configs]
-      hook_args = ''
-      hook_args <<= " -n #{args[:namespace]}" if args[:namespace]
-      hook_args <<= " -b #{args[:branch]}" if args[:branch]
-      hook = <<EOF
+module ModuleSync
+  class Hook
+    attr_reader :hook_file, :namespace, :branch, :args
+
+    def initialize(hook_file, options = [])
+      @hook_file = hook_file
+      @namespace = options['namespace']
+      @branch = options['branch']
+      @args = options['hook_args']
+    end
+
+    def content(arguments)
+      return <<-EOF
 #!/usr/bin/env bash
 
 current_branch=\`git symbolic-ref HEAD | sed -e 's,.*/\(.*\),\1,'\`
 git_dir=\`git rev-parse --show-toplevel\`
 message=\`git log -1 --format=%B\`
-msync -m "\$message"#{hook_args}
+msync -m "\$message" #{arguments}
 EOF
-      File.open("#{repo}/#{HOOK_FILE}", 'w') do |file|
-        file.write(hook)
+    end
+
+    def activate
+      hook_args = []
+      hook_args << "-n #{namespace}" if namespace
+      hook_args << "-b #{branch}" if branch
+      hook_args << args if args
+
+      File.open(hook_file, 'w') do |file|
+        file.write(content(hook_args.join(' ')))
       end
     end
 
-    def self.deactivate(repo)
-      hook_path = "#{repo}/#{HOOK_FILE}"
-      File.delete(hook_path) if File.exist?(hook_path)
-    end
-
-    def self.hook(command, args)
-      if (command == 'activate')
-        activate(args)
-      else
-        deactivate(args[:configs])
-      end
+    def deactivate
+      File.delete(hook_file) if File.exist?(hook_file)
     end
   end
 end

--- a/lib/modulesync/hook.rb
+++ b/lib/modulesync/hook.rb
@@ -12,7 +12,7 @@ module ModuleSync
     end
 
     def content(arguments)
-      return <<-EOF
+      <<-EOF
 #!/usr/bin/env bash
 
 current_branch=\`git symbolic-ref HEAD | sed -e 's,.*/\(.*\),\1,'\`


### PR DESCRIPTION
This commit moves ModuleSync::Hook from a module to a class. It also
adds the ability to define arbitrary arguments to add to the hook. I've
also broken up the `run` method. Instead of calling a monolithic `run`
method we now call `update` or `hook` methods based on the CLI option.